### PR TITLE
Fix artifax.utils.arglist to use inspect.signature instead of inspect.getfullargspec

### DIFF
--- a/artifax/utils.py
+++ b/artifax/utils.py
@@ -3,7 +3,7 @@
 
 import os
 from functools import reduce
-from inspect import getfullargspec
+from inspect import signature
 
 from . import exceptions
 
@@ -13,7 +13,7 @@ __license__ = "MIT"
 
 
 arglist = lambda v: (
-    getfullargspec(v).args if callable(v) else v.args() if isinstance(v, At) else []
+    list(signature(v).parameters.keys()) if callable(v) else v.args() if isinstance(v, At) else []
 )
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,14 @@
+from artifax.utils import arglist
+
+def test_arglist():
+
+    def f(foo, bar, bat):
+        print(foo, bar, bat)
+
+    def wrapper(*args):
+        f(*args)
+
+    import functools
+    functools.update_wrapper(wrapper, f)
+
+    assert set(arglist(f)) == set(arglist(wrapper))


### PR DESCRIPTION
Use inspect.signature instead of inspect.getfullargspec in artifax.utils.arglist, because inspect.getfullargspec is deprecated, and inspect.signature support functools.wrap utility.